### PR TITLE
Hugo/memoryleaks

### DIFF
--- a/app/src/main/java/com/breadwallet/tools/sqlite/BRSQLiteHelper.java
+++ b/app/src/main/java/com/breadwallet/tools/sqlite/BRSQLiteHelper.java
@@ -82,7 +82,25 @@ class BRSQLiteHelper extends SQLiteOpenHelper {
             PEER_PORT + " blob," +
             PEER_TIMESTAMP + " blob );";
 
-    public BRSQLiteHelper(Context context) {
+    /**
+     * Peer table
+     */
+    private static BRSQLiteHelper instance;
+
+    public static synchronized BRSQLiteHelper getInstance(Context context) {
+        if (instance == null) {
+            // Use the application context to make sure that we don't accidentally
+            // leak an Activity's context
+            instance = new BRSQLiteHelper(context.getApplicationContext());
+        }
+        return instance;
+    }
+
+    /**
+     * Constructor made private to prevent direct instantiation.
+     * Use getInstance() to get the static instance instead.
+     */
+    private BRSQLiteHelper(Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
     }
 

--- a/app/src/main/java/com/breadwallet/tools/sqlite/BRSQLiteHelper.java
+++ b/app/src/main/java/com/breadwallet/tools/sqlite/BRSQLiteHelper.java
@@ -83,7 +83,7 @@ class BRSQLiteHelper extends SQLiteOpenHelper {
             PEER_TIMESTAMP + " blob );";
 
     /**
-     * Peer table
+     * Singleton instance of BRSQLiteHelper
      */
     private static BRSQLiteHelper instance;
 

--- a/app/src/main/java/com/breadwallet/tools/sqlite/MerkleBlockDataSource.java
+++ b/app/src/main/java/com/breadwallet/tools/sqlite/MerkleBlockDataSource.java
@@ -54,7 +54,7 @@ class MerkleBlockDataSource {
     };
 
     public MerkleBlockDataSource(Context context) {
-        dbHelper = new BRSQLiteHelper(context);
+        dbHelper = BRSQLiteHelper.getInstance(context);
     }
 
     public void putMerkleBlocks(BlockEntity[] blockEntities) {

--- a/app/src/main/java/com/breadwallet/tools/sqlite/PeerDataSource.java
+++ b/app/src/main/java/com/breadwallet/tools/sqlite/PeerDataSource.java
@@ -53,7 +53,7 @@ class PeerDataSource {
     };
 
     public PeerDataSource(Context context) {
-        dbHelper = new BRSQLiteHelper(context);
+        dbHelper = BRSQLiteHelper.getInstance(context);
     }
 
     public void putPeers(PeerEntity[] peerEntities) {

--- a/app/src/main/java/com/breadwallet/tools/sqlite/TransactionDataSource.java
+++ b/app/src/main/java/com/breadwallet/tools/sqlite/TransactionDataSource.java
@@ -28,7 +28,6 @@ package com.breadwallet.tools.sqlite;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
-import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
 
@@ -53,7 +52,7 @@ public class TransactionDataSource {
 
 
     public TransactionDataSource(Context context) {
-        dbHelper = new BRSQLiteHelper(context);
+        dbHelper = BRSQLiteHelper.getInstance(context);
     }
 
     public BRTransactionEntity createTransaction(BRTransactionEntity transactionEntity) {
@@ -82,7 +81,6 @@ public class TransactionDataSource {
             database.endTransaction();
         }
         return null;
-
 
     }
 


### PR DESCRIPTION
**Problem**:
Multiple memory leaks:
`SQLiteConnectionPool: A SQLiteConnection object for database '/data/user/0/com.breadwallet/databases/breadwallet.db' was leaked!  Please fix your application to end transactions in progress properly and to close the database when it is no longer needed.`

**Cause**:
Currently a new instance of `SQLiteOpenHelper` is instantiated every time there is a database operation. This causes memory leaks and unnecessary allocations.

**Fix**:
Make `BRSQLiteHelper` a static singleton instance..