### PR TITLE
Hugo/redesign

### DIFF
--- a/app/src/main/java/com/breadwallet/presenter/fragments/FragmentReceive.java
+++ b/app/src/main/java/com/breadwallet/presenter/fragments/FragmentReceive.java
@@ -272,6 +272,10 @@ public class FragmentReceive extends Fragment {
     }
 
     private void updateQr() {
+        // TODO: This is a workaround so that the app doesn't crash on receiving litecoins...
+        // The proper fix: BRWalletManager should not rely on an Activity's context to function.
+        // It should hold on to the Application's context instead.
+        if (getContext() == null) return;
         boolean success = BRWalletManager.refreshAddress(getContext());
         if (!success) throw new RuntimeException("failed to retrieve address");
         getActivity().runOnUiThread(new Runnable() {

--- a/app/src/main/java/com/breadwallet/tools/sqlite/BRSQLiteHelper.java
+++ b/app/src/main/java/com/breadwallet/tools/sqlite/BRSQLiteHelper.java
@@ -39,7 +39,8 @@ public class BRSQLiteHelper extends SQLiteOpenHelper {
     }
 
     public static BRSQLiteHelper getInstance(Context context) {
-        if (instance == null) instance = new BRSQLiteHelper(context);
+        // Use the application context to ensure that we don't accidentally leak an Activity's context
+        if (instance == null) instance = new BRSQLiteHelper(context.getApplicationContext());
         return instance;
     }
 


### PR DESCRIPTION
-  fix context memory leak in BRSQLiteHelper
- work-around for getContext()==null crash when receiving litecoins (the proper fix is to have BRWalletManager hold on to the Application's context).