### PR TITLE
Make pin pad visible on Nexus 6P. Closes #26

### DIFF
--- a/app/src/main/res/layout/activity_pin_template.xml
+++ b/app/src/main/res/layout/activity_pin_template.xml
@@ -24,42 +24,39 @@
 
     <com.breadwallet.presenter.customviews.BRText
         android:id="@+id/description"
-        android:layout_width="wrap_content"
+        android:layout_width="368dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="32dp"
-        android:layout_marginTop="24dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="16dp"
         android:lineSpacingMultiplier="1.3"
         android:text="@string/UpdatePin.createInstruction"
         android:textColor="@color/almost_black"
         android:textSize="18sp"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintLeft_toLeftOf="@+id/title"
-        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/title"/>
 
     <com.breadwallet.presenter.customviews.BRKeyboard
         android:id="@+id/brkeyboard"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="280dp"
         android:layout_marginBottom="16dp"
-        android:layout_marginEnd="32dp"
-        android:layout_marginStart="32dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:showAlphabet="true"
-        />
+        app:showAlphabet="true"/>
 
     <com.breadwallet.presenter.customviews.BRText
         android:id="@+id/textView5"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"
-        android:layout_marginEnd="32dp"
         android:layout_marginTop="16dp"
         android:lineSpacingMultiplier="1.3"
         android:text="@string/WritePaperPhrase.instruction"
         android:textSize="16sp"
+        android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@+id/brkeyboard"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintLeft_toLeftOf="@+id/description"
@@ -84,14 +81,14 @@
         android:id="@+id/pinLayout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/bread_margin"
-        android:layout_marginStart="@dimen/bread_margin"
+        android:layout_marginBottom="8dp"
         android:layout_marginTop="48dp"
         android:orientation="horizontal"
-        app:layout_constraintHorizontal_bias="0.497"
+        app:layout_constraintBottom_toTopOf="@+id/brkeyboard"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/description">
+        app:layout_constraintTop_toBottomOf="@+id/description"
+        app:layout_constraintVertical_bias="0.33">
 
         <View
             android:id="@+id/dot1"

--- a/app/src/main/res/layout/fragment_bread_pin.xml
+++ b/app/src/main/res/layout/fragment_bread_pin.xml
@@ -95,12 +95,11 @@
     <com.breadwallet.presenter.customviews.BRKeyboard
         android:id="@+id/brkeyboard"
         android:layout_width="0dp"
-        android:paddingTop="8dp"
-        app:showAlphabet="true"
-        android:layout_height="wrap_content"
         android:background="@color/extra_light_blue_background"
+        android:layout_height="280dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"/>
-
+        app:layout_constraintRight_toRightOf="parent"
+        app:showAlphabet="true"/>
+    
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
As seen on previously not working Nexus 6P:

Their custom keypad can't handle left and right margins. This is the difference between this invisible pin pad and the visible one seen on the unlock screen.

I also hid the text about writing down words, that was in the wrong place.

![image](https://user-images.githubusercontent.com/6041352/34903120-2087b24a-f801-11e7-86e4-d0fcde41ee2b.png)

