### PR TITLE
Replace photons with LTC (Ł). Closes #15

### DIFF
--- a/app/src/main/java/com/breadwallet/presenter/activities/settings/DisplayCurrencyActivity.java
+++ b/app/src/main/java/com/breadwallet/presenter/activities/settings/DisplayCurrencyActivity.java
@@ -78,7 +78,7 @@ public class DisplayCurrencyActivity extends BRActivity {
         });
 
         int unit = BRSharedPrefs.getCurrencyUnit(this);
-        if (unit == BRConstants.CURRENT_UNIT_PHOTONS) {
+        if (unit == BRConstants.CURRENT_UNIT_LITECOINS) {
             setButton(true);
         } else {
             setButton(false);
@@ -110,15 +110,15 @@ public class DisplayCurrencyActivity extends BRActivity {
         CurrencyEntity entity = CurrencyDataSource.getInstance().getCurrencyByIso(iso);
         if (entity != null) {
             String finalExchangeRate = BRCurrency.getFormattedCurrencyString(DisplayCurrencyActivity.this, BRSharedPrefs.getIso(this), new BigDecimal(entity.rate));
-            boolean bits = BRSharedPrefs.getCurrencyUnit(this) == BRConstants.CURRENT_UNIT_PHOTONS;
-            exchangeText.setText(BRCurrency.getFormattedCurrencyString(this, "LTC", new BigDecimal(bits ? 1000000 : 1000)) + " = " + finalExchangeRate);
+            boolean lites = BRSharedPrefs.getCurrencyUnit(this) == BRConstants.CURRENT_UNIT_LITES;
+            exchangeText.setText(BRCurrency.getFormattedCurrencyString(this, "LTC", new BigDecimal(lites ? 1000 : 1)) + " = " + finalExchangeRate);
         }
         adapter.notifyDataSetChanged();
     }
 
     private void setButton(boolean left) {
         if (left) {
-            BRSharedPrefs.putCurrencyUnit(this, BRConstants.CURRENT_UNIT_PHOTONS);
+            BRSharedPrefs.putCurrencyUnit(this, BRConstants.CURRENT_UNIT_LITECOINS);
             leftButton.setTextColor(getColor(R.color.white));
             leftButton.setBackground(getDrawable(R.drawable.b_half_left_blue));
             rightButton.setTextColor(getColor(R.color.dark_blue));

--- a/app/src/main/java/com/breadwallet/tools/util/BRCurrency.java
+++ b/app/src/main/java/com/breadwallet/tools/util/BRCurrency.java
@@ -107,7 +107,7 @@ public class BRCurrency {
         decimalFormatSymbols.setCurrencySymbol(symbol);
 //        currencyFormat.setMaximumFractionDigits(decimalPoints);
         currencyFormat.setGroupingUsed(true);
-        currencyFormat.setMaximumFractionDigits(BRSharedPrefs.getCurrencyUnit(app) == BRConstants.CURRENT_UNIT_LITECOINS ? 8 : 2);
+        currencyFormat.setMaximumFractionDigits(getMaxDecimalPlaces(isoCurrencyCode));
         currencyFormat.setDecimalFormatSymbols(decimalFormatSymbols);
         currencyFormat.setNegativePrefix(decimalFormatSymbols.getCurrencySymbol() + "-");
         currencyFormat.setNegativeSuffix("");
@@ -174,6 +174,8 @@ public class BRCurrency {
 
         if (iso.equalsIgnoreCase("LTC")) {
             return 8;
+        } else if (iso.equalsIgnoreCase("lites")) {
+            return 5;
         } else {
             Currency currency = Currency.getInstance(iso);
             return currency.getDefaultFractionDigits();

--- a/app/src/main/java/com/platform/middlewares/plugins/WalletPlugin.java
+++ b/app/src/main/java/com/platform/middlewares/plugins/WalletPlugin.java
@@ -80,7 +80,7 @@ public class WalletPlugin implements Plugin {
                 jsonResp.put("receive_address", BRWalletManager.getReceiveAddress());
 
                 /**how digits after the decimal point. 2 = bits 8 = btc 6 = mbtc*/
-                jsonResp.put("ltc_denomiation_digits", BRSharedPrefs.getCurrencyUnit(context) == BRConstants.CURRENT_UNIT_LITECOINS ? 8 : 2);
+                jsonResp.put("ltc_denomiation_digits", BRSharedPrefs.getCurrencyUnit(context) == BRConstants.CURRENT_UNIT_LITECOINS ? 8 : 5);
 
                 /**the users native fiat currency as an ISO 4217 code. Should be uppercased */
                 jsonResp.put("local_currency_code", Currency.getInstance(Locale.getDefault()).getCurrencyCode().toUpperCase());

--- a/app/src/main/res/layout/activity_display_currency.xml
+++ b/app/src/main/res/layout/activity_display_currency.xml
@@ -72,7 +72,7 @@
             android:layout_height="30dp"
             android:layout_weight="1.0"
             android:background="@drawable/b_half_left_blue"
-            android:text="photons (mł)"
+            android:text="LTC (Ł)"
             android:textColor="@color/white"
             android:textSize="14sp"
             android:padding="0dp"


### PR DESCRIPTION
- Also fix decimal places display on the settings screen

Settings LTC: (note the 0dp fiat currency YEN is displayed correctly)

![image](https://user-images.githubusercontent.com/6041352/34966746-5b4dcf06-fa34-11e7-805f-72e753d2daec.png)

Settings (lites):

![image](https://user-images.githubusercontent.com/6041352/34966758-6f4eb3d0-fa34-11e7-836e-dce2e03e8373.png)

Litecoin display:

![image](https://user-images.githubusercontent.com/6041352/34966764-8090ae46-fa34-11e7-8656-816c795ac14f.png)

Litecoin transaction:

![image](https://user-images.githubusercontent.com/6041352/34966772-91821e42-fa34-11e7-90e5-4b218f5776f0.png)

Lites display:

![image](https://user-images.githubusercontent.com/6041352/34966779-a9ead528-fa34-11e7-9310-c6d29d7ab5de.png)

Lites transaction:

![image](https://user-images.githubusercontent.com/6041352/34966783-b950202c-fa34-11e7-9961-1302066afd26.png)
