### PR TITLE
Fix crash occurred on arabic devices

### DIFF
--- a/app/src/main/java/com/breadwallet/tools/util/Utils.java
+++ b/app/src/main/java/com/breadwallet/tools/util/Utils.java
@@ -216,7 +216,7 @@ public class Utils {
                 e.printStackTrace();
             }
         }
-        return String.format("%s/%d %s Android/%s", "Litewallet", versionNumber, cfnetwork, Build.VERSION.RELEASE, Locale.ENGLISH);
+        return String.format(Locale.ENGLISH, "%s/%d %s Android/%s", "Litewallet", versionNumber, cfnetwork, Build.VERSION.RELEASE);
     }
 
     public static String reverseHex(String hex) {


### PR DESCRIPTION
Fatal Exception: java.lang.IllegalArgumentException: Unexpected char 0x6f6 at 11 in User-agent value: Litewallet/۶۰۲ android/HttpURLConnection Android/9
       at okhttp3.Headers$Companion.checkValue(Headers.kt:434)
       at okhttp3.Headers$Companion.access$checkValue(Headers.kt:346)
       at okhttp3.Headers$Builder.set(Headers.kt:328)
       at okhttp3.Request$Builder.header(Request.kt:199)
       at com.breadwallet.tools.manager.BRApiManager.urlGET(BRApiManager.java:227)
       at com.breadwallet.tools.manager.BRApiManager.updateFeePerKb(BRApiManager.java:192)
       at com.platform.APIClient$4.run(APIClient.java:794)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
       at com.breadwallet.tools.threads.PriorityThreadFactory$1.run(PriorityThreadFactory.java:47)
       at java.lang.Thread.run(Thread.java:764)