### PR TITLE
Fix NPE on FingerprintManager.isHardwareDetected()

### DIFF
--- a/app/src/main/java/com/breadwallet/tools/util/Utils.java
+++ b/app/src/main/java/com/breadwallet/tools/util/Utils.java
@@ -216,7 +216,7 @@ public class Utils {
                 e.printStackTrace();
             }
         }
-        return String.format("%s/%d %s Android/%s", "Litewallet", versionNumber, cfnetwork, Build.VERSION.RELEASE, Locale.ENGLISH);
+        return String.format(Locale.ENGLISH, "%s/%d %s Android/%s", "Litewallet", versionNumber, cfnetwork, Build.VERSION.RELEASE);
     }
 
     public static String reverseHex(String hex) {

--- a/app/src/main/java/com/breadwallet/tools/util/Utils.java
+++ b/app/src/main/java/com/breadwallet/tools/util/Utils.java
@@ -179,6 +179,9 @@ public class Utils {
 
     public static boolean isFingerprintEnrolled(Context app) {
         FingerprintManager fingerprintManager = (FingerprintManager) app.getSystemService(FINGERPRINT_SERVICE);
+        if (fingerprintManager == null) {
+            return false;
+        }
         // Device doesn't support fingerprint authentication
         return ActivityCompat.checkSelfPermission(app, Manifest.permission.USE_FINGERPRINT) == PackageManager.PERMISSION_GRANTED && fingerprintManager.isHardwareDetected() && fingerprintManager.hasEnrolledFingerprints();
     }


### PR DESCRIPTION
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.hardware.fingerprint.FingerprintManager.isHardwareDetected()' on a null object reference
       at com.breadwallet.tools.util.Utils.isFingerprintEnrolled(Utils.java:183)
       at com.breadwallet.presenter.activities.settings.SecurityCenterActivity.updateList(SecurityCenterActivity.java:163)
       at com.breadwallet.presenter.activities.settings.SecurityCenterActivity.onCreate(SecurityCenterActivity.java:73)
       at android.app.Activity.performCreate(Activity.java:7136)
       at android.app.Activity.performCreate(Activity.java:7127)
       at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1271)
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2924)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3079)
       at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:78)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1836)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:193)
       at android.app.ActivityThread.main(ActivityThread.java:6702)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:911)