### PR TITLE
bech32 changes

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -60,6 +60,9 @@ add_library( # Specifies the name of the library.
              src/main/jni/loafwallet-core/BRTransaction.h
              src/main/jni/loafwallet-core/BRWallet.c
              src/main/jni/loafwallet-core/BRWallet.h
+             src/main/jni/loafwallet-core/BRChainParams.h
+             src/main/jni/loafwallet-core/BRBech32.c
+             src/main/jni/loafwallet-core/BRBech32.h
 
              src/main/jni/transition/core.c
              src/main/jni/transition/core.h

--- a/app/src/main/jni/transition/PeerManager.c
+++ b/app/src/main/jni/transition/PeerManager.c
@@ -39,6 +39,12 @@
 
 #define fprintf(...) __android_log_print(ANDROID_LOG_ERROR, "bread", _va_rest(__VA_ARGS__, NULL))
 
+#if LITECOIN_TESTNET
+#define BR_CHAIN_PARAMS BRTestNetParams
+#else
+#define BR_CHAIN_PARAMS BRMainNetParams
+#endif
+
 static BRMerkleBlock **_blocks;
 BRPeerManager *_peerManager;
 static JavaVM *_jvmPM;
@@ -291,7 +297,7 @@ Java_com_breadwallet_wallet_BRPeerManager_create(JNIEnv *env, jobject thiz,
         if (earliestKeyTime < BIP39_CREATION_TIME) earliestKeyTime = BIP39_CREATION_TIME;
         __android_log_print(ANDROID_LOG_DEBUG, "Message from C: ", "earliestKeyTime: %d",
                             earliestKeyTime);
-        _peerManager = BRPeerManagerNew(_wallet, (uint32_t) earliestKeyTime, _blocks,
+        _peerManager = BRPeerManagerNew(&BR_CHAIN_PARAMS, _wallet, (uint32_t) earliestKeyTime, _blocks,
                                         (size_t) blocksCount,
                                         _peers, (size_t) peersCount);
         BRPeerManagerSetCallbacks(_peerManager, NULL, syncStarted, syncStopped,
@@ -422,7 +428,7 @@ JNIEXPORT jboolean JNICALL Java_com_breadwallet_wallet_BRPeerManager_isCreated(J
 JNIEXPORT jboolean JNICALL Java_com_breadwallet_wallet_BRPeerManager_isConnected(JNIEnv *env,
                                                                                  jobject obj) {
     __android_log_print(ANDROID_LOG_DEBUG, "Message from C: ", "isConnected");
-    return (jboolean) (_peerManager && BRPeerManagerIsConnected(_peerManager));
+    return (jboolean) (_peerManager && BRPeerManagerConnectStatus(_peerManager) == BRPeerStatusConnected);
 }
 
 JNIEXPORT jint JNICALL Java_com_breadwallet_wallet_BRPeerManager_getEstimatedBlockHeight(
@@ -459,7 +465,7 @@ JNIEXPORT jboolean JNICALL Java_com_breadwallet_wallet_BRPeerManager_setFixedPee
         if (inet_pton(AF_INET, host, &addr) != 1) return JNI_FALSE;
         address.u16[5] = 0xffff;
         address.u32[3] = addr.s_addr;
-        if (port == 0) _port = STANDARD_PORT;
+        if (port == 0) _port = BRPeerManagerStandardPort(_peerManager);
     } else {
         _port = 0;
     }

--- a/app/src/main/jni/transition/wallet.c
+++ b/app/src/main/jni/transition/wallet.c
@@ -136,7 +136,7 @@ static void txAdded(void *info, BRTransaction *tx) {
     (*env)->SetByteArrayRegion(env, result, 0, (jsize) len, (jbyte *) buf);
 
     UInt256 transactionHash = tx->txHash;
-    const char *strHash = u256_hex_encode(transactionHash);
+    const char *strHash = u256hex(transactionHash);
     jstring jstrHash = (*env)->NewStringUTF(env, strHash);
 
     (*env)->CallStaticVoidMethod(env, _walletManagerClass, mid, result, (jint) tx->blockHeight,
@@ -158,7 +158,7 @@ static void txUpdated(void *info, const UInt256 txHashes[], size_t count, uint32
                                               "(Ljava/lang/String;II)V");
 
     for (size_t i = 0; i < count; i++) {
-        const char *strHash = u256_hex_encode(txHashes[i]);
+        const char *strHash = u256hex(txHashes[i]);
         jstring JstrHash = (*env)->NewStringUTF(env, strHash);
 
         (*env)->CallStaticVoidMethod(env, _walletManagerClass, mid, JstrHash, (jint) blockHeight,
@@ -175,7 +175,7 @@ static void txDeleted(void *info, UInt256 txHash, int notifyUser, int recommendR
 
     if (!env || _walletManagerClass == NULL) return;
 
-    const char *strHash = u256_hex_encode(txHash);
+    const char *strHash = u256hex(txHash);
 
     //create class
     jmethodID mid = (*env)->GetStaticMethodID(env, _walletManagerClass, "onTxDeleted",
@@ -319,7 +319,7 @@ Java_com_breadwallet_wallet_BRWalletManager_putTransaction(JNIEnv *env, jobject 
     tmpTx->timestamp = (uint32_t) jTimeStamp;
 //    __android_log_print(ANDROID_LOG_ERROR, "Message from C: ", "tmpTx->timestamp: %u",
 //                        tmpTx->timestamp);
-//    __android_log_print(ANDROID_LOG_ERROR, "Message from C: ", "tmpTx: %s", u256_hex_encode(tmpTx->txHash));
+//    __android_log_print(ANDROID_LOG_ERROR, "Message from C: ", "tmpTx: %s", u256hex(tmpTx->txHash));
     _transactions[_transactionsCounter++] = tmpTx;
 
 }
@@ -380,7 +380,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_breadwallet_wallet_BRWalletManager_getTr
 
         UInt256 reversedHash = UInt256Reverse((txid));
 
-        jstring txReversed = (*env)->NewStringUTF(env, u256_hex_encode(reversedHash));
+        jstring txReversed = (*env)->NewStringUTF(env, u256hex(reversedHash));
 
 
         jlong Jsent = (jlong) BRWalletAmountSentByTx(_wallet, tempTx);
@@ -576,7 +576,7 @@ Java_com_breadwallet_wallet_BRWalletManager_transactionIsVerified(JNIEnv *env, j
     if (!_wallet) return JNI_FALSE;
 
     const char *txHash = (*env)->GetStringUTFChars(env, jtxHash, NULL);
-    UInt256 txHashResult = u256_hex_decode(txHash);
+    UInt256 txHashResult = uint256(txHash);
     BRTransaction *tx = BRWalletTransactionForHash(_wallet, txHashResult);
 
     if (!tx) return JNI_FALSE;
@@ -865,10 +865,10 @@ Java_com_breadwallet_wallet_BRWalletManager_reverseTxHash(JNIEnv *env, jobject t
     __android_log_print(ANDROID_LOG_DEBUG, "Message from C: ", "reverseTxHash");
 
     const char *rawString = (*env)->GetStringUTFChars(env, txHash, 0);
-    UInt256 theHash = u256_hex_decode(rawString);
+    UInt256 theHash = uint256(rawString);
     UInt256 reversedHash = UInt256Reverse(theHash);
 
-    return (*env)->NewStringUTF(env, u256_hex_encode(reversedHash));
+    return (*env)->NewStringUTF(env, u256hex(reversedHash));
 }
 
 JNIEXPORT jstring JNICALL
@@ -882,10 +882,10 @@ Java_com_breadwallet_wallet_BRWalletManager_txHashToHex(JNIEnv *env, jobject thi
     UInt256 reversedHash = UInt256Reverse((*(UInt256 *) hash));
 
 //    const char *rawString = (*env)->GetStringUTFChars(env, txHash, 0);
-//    UInt256 theHash = u256_hex_decode(rawString);
+//    UInt256 theHash = uint256(rawString);
 //    UInt256 reversedHash = UInt256Reverse(theHash);
 //
-    return (*env)->NewStringUTF(env, u256_hex_encode(reversedHash));
+    return (*env)->NewStringUTF(env, u256hex(reversedHash));
 }
 
 
@@ -895,14 +895,14 @@ Java_com_breadwallet_wallet_BRWalletManager_txHashSha256Hex(JNIEnv *env, jobject
     __android_log_print(ANDROID_LOG_DEBUG, "Message from C: ", "reverseTxHash");
 
     const char *rawString = (*env)->GetStringUTFChars(env, txHash, 0);
-    UInt256 theHash = u256_hex_decode(rawString);
+    UInt256 theHash = uint256(rawString);
 //    UInt256 reversedHash = UInt256Reverse(theHash);
-//    __android_log_print(ANDROID_LOG_DEBUG, "Message from C: ", "reversedHash: %s", u256_hex_encode(reversedHash));
+//    __android_log_print(ANDROID_LOG_DEBUG, "Message from C: ", "reversedHash: %s", u256hex(reversedHash));
     UInt256 sha256Hash;
     BRSHA256(&sha256Hash, theHash.u8, sizeof(theHash));
 
 //    UInt256 reversedHash = UInt256Reverse(sha256Hash);
-    char *result = u256_hex_encode(sha256Hash);
+    char *result = u256hex(sha256Hash);
     return (*env)->NewStringUTF(env, result);
 }
 


### PR DESCRIPTION
This PR attempts to enable bech32 support on Litewallet for Android. This should address issues with older devices such as the J2.

**How to Test**
1. checkout to `losh11/bech32` branch
2. init submodules
3. cd into `loafwallet-core` module
4. checkout to `losh11/bech32` branch in submodule
5. test send/receive from and to bech32 address.
6. erase litewallet on device, and reinstall. recover and wait to finish syncing to check if all transactions are still visible.

**Prerequisites**
This commit requires PR 21 in `loafwallet-core` to be merged, and an additional commit must be made updating the submodule to this PR.

Recommended to rebase and merge into dev branch.