### PR TITLE
feat(card tab): hide for non-US users

### DIFF
--- a/app/src/main/java/com/breadwallet/presenter/activities/BreadActivity.java
+++ b/app/src/main/java/com/breadwallet/presenter/activities/BreadActivity.java
@@ -9,6 +9,7 @@ import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
+import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 import android.view.ViewTreeObserver;
 import android.view.animation.AnimationUtils;
@@ -391,6 +392,8 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
     private void initializeViews() {
         menuBut = findViewById(R.id.menuBut);
         bottomNav = findViewById(R.id.bottomNav);
+        bottomNav.getMenu().clear();
+        bottomNav.inflateMenu(isInUsa() ? R.menu.bottom_nav_menu_us : R.menu.bottom_nav_menu);
         ltcPriceLbl = findViewById(R.id.price_change_text);
         ltcPriceDateLbl = findViewById(R.id.priceDateLbl);
         balanceTxtV = findViewById(R.id.balanceTxtV);
@@ -417,6 +420,11 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
 
         ltcPriceLbl.setTextSize(PRIMARY_TEXT_SIZE);
         balanceTxtV.append(":");
+    }
+
+    private boolean isInUsa() {
+        TelephonyManager telManager = (TelephonyManager) getSystemService(TELEPHONY_SERVICE);
+        return "us".equals(telManager.getSimCountryIso());
     }
 
     @Override

--- a/app/src/main/res/layout/activity_bread.xml
+++ b/app/src/main/res/layout/activity_bread.xml
@@ -171,6 +171,6 @@
         app:backgroundTint="@color/litecoin_litewallet_blue"
         app:itemIconTint="@color/bottom_nav_icon_tint_selector"
         app:labelVisibilityMode="labeled"
-        app:menu="@menu/bottom_nav_menu" />
+        tools:menu="@menu/bottom_nav_menu_us" />
 
 </RelativeLayout>

--- a/app/src/main/res/menu/bottom_nav_menu_us.xml
+++ b/app/src/main/res/menu/bottom_nav_menu_us.xml
@@ -14,6 +14,12 @@
         android:title="@string/Button.send" />
 
     <item
+        android:id="@+id/nav_card"
+        android:enabled="true"
+        android:icon="@drawable/ic_nav_spend"
+        android:title="@string/BottomNavItem.Card.title" />
+
+    <item
         android:id="@+id/nav_receive"
         android:enabled="true"
         android:icon="@drawable/ic_nav_receive"


### PR DESCRIPTION
## Problem
The users are using Litewallet and some are located outside the US which means they are unable to use the Litecoin Card. This causes major support issues and generally makes Litewallet bad as a product. There is also a lot confusion about what the Card does and who does what.

## Approach
- Check the SIM provider's country code: If "us" show up the card tab otherwise hide it.
