### PR TITLE
[Tech Debt] Update the support URL

### DIFF
--- a/app/src/main/java/com/breadwallet/tools/util/BRConstants.java
+++ b/app/src/main/java/com/breadwallet/tools/util/BRConstants.java
@@ -75,7 +75,7 @@ public class BRConstants {
     public static final String ECONOMY_FEE_KB_PREFS = "EconomyFeeKb";
     public static final String LITTLE_CIRCLE = "\u2022";
 
-    public static String SUPPORT_EMAIL = "support.litewallet.io";
+    public static String SUPPORT_EMAIL = "support@litecoinfoundation.zendesk.com";
 
     public static final int ONE_BITCOIN = 100000000;
 

--- a/app/src/main/java/com/breadwallet/tools/util/BRConstants.java
+++ b/app/src/main/java/com/breadwallet/tools/util/BRConstants.java
@@ -75,7 +75,7 @@ public class BRConstants {
     public static final String ECONOMY_FEE_KB_PREFS = "EconomyFeeKb";
     public static final String LITTLE_CIRCLE = "\u2022";
 
-    public static String SUPPORT_EMAIL = "support@litecoinfoundation.zendesk.com";
+    public static String SUPPORT_EMAIL = "support.litewallet.io";
 
     public static final int ONE_BITCOIN = 100000000;
 
@@ -129,7 +129,7 @@ public class BRConstants {
     public static final String REDDIT_LINK = "https://www.reddit.com/r/Litewallet";
     public static final String WEB_LINK = "https://lite-wallet.org";
     public static final String TOS_LINK = "https://lite-wallet.org/policy";
-    public static String CUSTOMER_SUPPORT_LINK = "https://litecoinfoundation.zendesk.com";
+    public static String CUSTOMER_SUPPORT_LINK = "https://support.litewallet.io";
 
     public static final String BLOCK_EXPLORER_BASE_URL = BuildConfig.LITECOIN_TESTNET ? "https://testnet.litecore.io/tx/" : "https://insight.litecore.io/tx/";
 


### PR DESCRIPTION
Update the support URL from litecoinfoundation.zendesk.com to support.litewallet.io